### PR TITLE
Madninja/tech state notify

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"ebus">>,
   {git,"https://github.com/helium/ebus",
-       {ref,"016be945878bc25b9e4b1bf2c07727685612e85d"}},
+       {ref,"de7a2e0759532748bc04373a520a08d9bca2d3ba"}},
   0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.5">>},0}]}.

--- a/src/connman.erl
+++ b/src/connman.erl
@@ -7,7 +7,8 @@
 -export([connman/0]).
 %% API
 -export([state/1, state/2,
-         register_state_notify/2, unregister_state_notify/2,
+         register_state_notify/3, register_state_notify/4,
+         unregister_state_notify/4,
          enable/3, scan/2, technologies/1,
          services/1, service_names/1,
          connect/4]).
@@ -71,21 +72,19 @@ state(Pid) ->
 state(Pid, Type) ->
     gen_server:call(Pid, {state, Type}).
 
--spec register_state_notify(pid(), Handler::pid()) -> ok.
-register_state_notify(Pid, Handler) ->
-    register_state_notify(Pid, global, Handler).
+-spec register_state_notify(pid(), Handler::pid(), Info::any())
+                           -> {ok, SignalID::ebus:filter_id()} | {error, term()}.
+register_state_notify(Pid, Handler, Info) ->
+    register_state_notify(Pid, global, Handler, Info).
 
--spec register_state_notify(pid(), state_type(), Handler::pid()) -> ok.
-register_state_notify(Pid, Type, Handler) ->
-    gen_server:cast(Pid, {register_state_notify, Type, Handler}).
+-spec register_state_notify(pid(), state_type(), Handler::pid(), Info::any())
+                           -> {ok, SignalID::ebus:filter_id()} | {error, term()}.
+register_state_notify(Pid, Type, Handler, Info) ->
+    gen_server:call(Pid, {register_state_notify, Type, Handler, Info}).
 
--spec unregister_state_notify(pid(), Handler::pid()) -> ok.
-unregister_state_notify(Pid, Handler) ->
-    unregister_state_notify(Pid, global, Handler).
-
--spec unregister_state_notify(pid(), state_type(), Handler::pid()) -> ok.
-unregister_state_notify(Pid, Type, Handler) ->
-    gen_server:cast(Pid, {unregister_state_notify, Type, Handler}).
+-spec unregister_state_notify(pid(), SignalID::ebus:filter_id(), Handler::pid(), Info::any()) -> ok.
+unregister_state_notify(Pid, SignalID, Handler, Info) ->
+    gen_server:call(Pid, {unregister_state_notify, SignalID, Handler, Info}).
 
 %% @doc Enable or disable the given `Tech'.
 -spec enable(pid(), technology(), boolean()) -> ok | {error, term()}.

--- a/src/connman_agent.erl
+++ b/src/connman_agent.erl
@@ -27,7 +27,8 @@ init([Proxy, AgentName, InputModule, InputState]) ->
                 input_module=InputModule, input_state=InputState}}.
 
 
-handle_message("RequestInput", Msg, State=#state{input_module=InputModule, input_state=InputState}) ->
+handle_message("net.connman.Agent.RequestInput", Msg,
+               State=#state{input_module=InputModule, input_state=InputState}) ->
     case ebus_message:args(Msg) of
         {ok, [ServicePath, Specs]} ->
             case InputModule:handle_input_request(InputState, ServicePath, Specs) of


### PR DESCRIPTION
This CHANGES the connman(un)register_state_notify functions to use the newly exposed ebus add/remove_signal_handler helpers. 

**Note**: this means you will now get a `{ebus_signal, Info, SIgnalID, Msg}` when the state changes where the signal id is the one returned by register_state_notify. Info is whatever extra info you pass in when calling register_state_notify. 