### PR TITLE
Add read cache for services

### DIFF
--- a/include/connman.hrl
+++ b/include/connman.hrl
@@ -1,0 +1,3 @@
+-define(CONNMAN_SERVICE, "net.connman").
+-define(CONNMAN_PATH_TECH, "/net/connman/technology").
+-define(CONNMAN_PATH_TECH(T), "/net/connman/technology" ++ "/" ++ atom_to_list(T)).

--- a/src/connman_connect.erl
+++ b/src/connman_connect.erl
@@ -7,17 +7,15 @@
                handler :: pid(),
                proxy :: pid(),
                service_name :: string(),
-               service_path=undefined :: string() | undefined,
-               services_signal_id :: ebus:filter_id()
+               service_path=undefined :: string() | undefined
               }).
 
 %% gen_statem
--export([callback_mode/0, start/4, start_link/4, init/1, terminate/2,
+-export([callback_mode/0, start/4, start_link/4, init/1,
          searching/3, connecting/3]).
 
--define(SEARCH_TIMEOUT, 5000).
+-define(SEARCH_TIMEOUT, 10000).
 -define(CONNECT_RESULT(T, R), {connect_result, T, self(), R}).
--define(SERVICES_SIGNAL_INFO, connman_connect).
 
 callback_mode() -> state_functions.
 
@@ -28,50 +26,22 @@ start_link(Proxy, Tech, ServiceName, Handler) ->
     gen_statem:start_link(?MODULE, [Proxy, Tech, ServiceName, Handler], []).
 
 init([Proxy, Tech, ServiceName, Handler]) ->
-    {ok, ServicesSignal} =
-        ebus_proxy:add_signal_handler(Proxy, "/", "net.connman.Manager.ServicesChanged",
-                                      self(), ?SERVICES_SIGNAL_INFO),
-    %% Kick of a scan to speed up service discovery
-    scan(Tech, Proxy),
-    self() ! find_service,
+    erlang:send_after(?SEARCH_TIMEOUT, self(), timeout_find_service),
     {ok, searching,
-     #data{proxy=Proxy, tech=Tech, handler=Handler,
-           service_name=ServiceName, services_signal_id=ServicesSignal},
+     #data{proxy=Proxy, tech=Tech, handler=Handler, service_name=ServiceName},
      {next_event, info, find_service}}.
 
-searching(info, find_service, Data=#data{handler=Handler}) ->
-    case connman:get_services(Data#data.proxy) of
-        {ok, Services} ->
-            erlang:send_after(?SEARCH_TIMEOUT, self(), timeout_find_service),
-            {keep_state, Data, {next_event, info, {find_service, Services}}};
-        {error, timeout} ->
-            lager:notice("Timeout finding SSID ~p, retrying", [Data#data.service_name]),
-            erlang:send_after(1000, self(), find_service),
-            keep_state_and_data;
-        {error, Error} ->
-            Handler ! ?CONNECT_RESULT(Data#data.tech, {error, Error}),
-            {stop, normal, Data}
-
-    end;
-searching(info, {ebus_signal, _, SignalID, Msg}, Data=#data{services_signal_id=SignalID}) ->
-    %% If the service wasn't found before using get_services it may
-    %% appear in the changed list as a new service.
-    case ebus_message:args(Msg) of
-        {ok, [Changed, _]} ->
-            {keep_state, Data, {next_event, info, {find_service, Changed}}};
-        {error, Error} ->
-            lager:notice("Filter match error: ~p", [Error]),
-            keep_state_and_data
-    end;
-searching(info, {find_service, Services}, Data=#data{}) ->
-    case find_service(Data#data.service_name, Services) of
+searching(info, find_service, Data=#data{}) ->
+    case find_service(Data#data.service_name, connman:services()) of
         false ->
+            erlang:send_after(1000, self(), find_service),
             keep_state_and_data;
         {Path, _Map} ->
             {next_state, connecting, Data#data{service_path=Path},
              {next_event, info, connect_service}}
     end;
 searching(info, timeout_find_service, Data=#data{handler=Handler}) ->
+    lager:info("Failed to find SSID ~p", Data#data.service_name),
     Handler ! ?CONNECT_RESULT(Data#data.tech, {error, not_found}),
     {stop, normal, Data};
 searching(Type, Msg, Data=#data{}) ->
@@ -84,7 +54,7 @@ connecting(info, connect_service, Data=#data{proxy=Proxy, service_path=Path, han
     case ebus_proxy:call(Proxy, Path, "net.connman.Service.Connect") of
         {error, unknown} ->
             %% Service disappeared while trying to connect. Scan and go back to searching
-            scan(Data#data.tech, Proxy),
+            connman:scan(Data#data.tech),
             {next_state, searching, Data};
         {error,"net.connman.Error.AlreadyConnected"} ->
             Handler ! ?CONNECT_RESULT(Tech, ok),
@@ -99,19 +69,12 @@ connecting(info, connect_service, Data=#data{proxy=Proxy, service_path=Path, han
 connecting(Type, Msg, Data=#data{}) ->
     handle_event(Type, Msg, Data).
 
-terminate(_, Data=#data{}) ->
-    ebus_proxy:remove_signal_handler(Data#data.proxy,
-                                     Data#data.services_signal_id,
-                                     self(),
-                                     ?SERVICES_SIGNAL_INFO).
-
-
 %%
 %% Internal
 %%
 
 
-handle_event(info, {find_service, _}, #data{}) ->
+handle_event(info, find_service, #data{}) ->
     %% handled only by searching
     keep_state_and_data;
 handle_event(info, {ebus_signal, _, _, _}, #data{}) ->
@@ -132,9 +95,3 @@ find_service(Name, Services) ->
         [] -> false;
         [Entry] -> Entry
     end.
-
-scan(wifi, Proxy) ->
-    ebus_proxy:send(Proxy, "/net/connman/technology/wifi", "net.connman.Technology.Scan"),
-    ok;
-scan(_, _) ->
-    ok.

--- a/src/connman_services.erl
+++ b/src/connman_services.erl
@@ -1,0 +1,136 @@
+-module(connman_services).
+
+-behavior(gen_server).
+-include("connman.hrl").
+
+-define(SERVICES_SIGNAL_INFO, connman_services).
+
+-record(state, {
+                proxy :: bus:proxy(),
+                services=[] :: [connman:service_descriptor()],
+                services_pid=undefined :: pid() | undefined,
+                services_signal_id=-1 :: ebus:signal_id()
+               }).
+
+%% gen_server
+-export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+% APIA
+-export([services/0, service_names/0, scan/1]).
+
+%% API
+
+-spec scan(connman:technology()) -> ok | {error, term()}.
+scan(Tech) ->
+    gen_server:call(?MODULE, {scan, Tech}).
+
+-spec services() -> [connman:service_descriptor()].
+services() ->
+    gen_server:call(?MODULE, services).
+
+-spec service_names() -> [string()].
+service_names() ->
+    lists:foldl(fun({_, M}, Acc) ->
+                        case maps:get("Name", M, false) of
+                            false -> Acc;
+                            Name -> [Name | Acc]
+                        end
+                end, [], services()).
+
+
+start_link(Bus) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [Bus], []).
+
+init([Bus]) ->
+    {ok, Proxy} = ebus_proxy:start_link(Bus, ?CONNMAN_SERVICE, []),
+    self() ! init_services,
+    {ok, #state{proxy=Proxy}}.
+
+
+handle_call({scan, Tech}, _From, State=#state{}) ->
+    {reply, start_scan(Tech, State), State};
+handle_call(services, _From, State=#state{}) ->
+    {reply, State#state.services, State};
+
+handle_call(Msg, _From, State=#state{}) ->
+    lager:warning("Unhandled call ~p", [Msg]),
+    {reply, ok, State}.
+
+handle_cast(Msg, State=#state{}) ->
+    lager:warning("Unhandled cast ~p", [Msg]),
+    {noreply, State}.
+
+
+handle_info(init_services, State=#state{proxy=Proxy}) ->
+    Parent = self(),
+    ServicesPid = spawn_link(fun() ->
+                                     Parent ! {get_services, get_services(Proxy)}
+                             end),
+    {ok, ServicesSignal} =
+        ebus_proxy:add_signal_handler(Proxy, "/", "net.connman.Manager.ServicesChanged",
+                                      self(), ?SERVICES_SIGNAL_INFO),
+    %% Kick of a scan on wifi to speed up service discovery
+    start_scan(wifi, State),
+    {noreply, State#state{services_signal_id=ServicesSignal, services_pid=ServicesPid}};
+handle_info({get_services, Result}, State=#state{}) ->
+    case Result of
+        {ok, Services} ->
+            NewServices = merge_services(State#state.services, Services),
+            {noreply, State#state{services=NewServices, services_pid=undefined}};
+        {error, Error} ->
+            lager:warning("Failed to fetch services ~p, falling back on signals", [Error]),
+            {noreply, State#state{services_pid=undefined}}
+    end;
+handle_info({ebus_signal, _, SignalID, Msg}, State=#state{services_signal_id=SignalID}) ->
+    %% If the service wasn't found before using get_services it may
+    %% appear in the changed list as a new service.
+    case ebus_message:args(Msg) of
+        {ok, [Changed, Removed]} ->
+            %% Merge in the changes
+            NewServices1 = merge_services(State#state.services, Changed),
+            %% And delete any removed
+            RemovedSet = sets:from_list(Removed),
+            NewServices2 = lists:filter(fun({Path, _}) ->
+                                                not sets:is_element(Path, RemovedSet)
+                                        end, NewServices1),
+            {noreply, State#state{services=NewServices2}};
+        {error, Error} ->
+            lager:notice("Filter match error: ~p", [Error]),
+            {noreply, State}
+    end;
+
+handle_info(Msg, State) ->
+    lager:warning("Unhandled info ~p", [Msg]),
+    {noreply, State}.
+
+
+terminate(_, State=#state{}) ->
+    ebus_proxy:remove_signal_handler(State#state.proxy,
+                                     State#state.services_signal_id,
+                                     self(),
+                                     ?SERVICES_SIGNAL_INFO).
+
+%%
+%% Internal
+%%
+
+start_scan(Tech, State=#state{}) ->
+    ebus_proxy:send(State#state.proxy, ?CONNMAN_PATH_TECH(Tech),
+                    "net.connman.Technology.Scan").
+
+-spec get_services(ebus:proxy()) -> {ok, [connman:service_descriptor()]}  | {error, term()}.
+get_services(Proxy) ->
+    case ebus_proxy:call(Proxy, "/", "net.connman.Manager.GetServices", [], [], 15000) of
+        {ok, [Services]} -> {ok, Services};
+        {error, Error} -> {error, Error}
+    end.
+
+-spec merge_services([connman:service_descriptor()], [connman:service_descriptor()])
+                    -> [connman:service_descriptor()].
+merge_services(CurrentServices, NewServices) ->
+    lists:foldl(fun({Path, Map}, Acc)->
+                        StoredMap = case lists:keyfind(Path, 1, Acc) of
+                                        false -> #{};
+                                        {_, M} -> M
+                                    end,
+                        lists:keystore(Path, 1, Acc, {Path, maps:merge(StoredMap, Map)})
+                end, CurrentServices, NewServices).


### PR DESCRIPTION
Fetching and updating the service descriptor cache can take a long
time. This creates a seperate service to manage the known set of
service records